### PR TITLE
Add Githhub Workflow to link Flutter SDK to Docs Workflow

### DIFF
--- a/.github/workflows/notify_docusaurus.yml
+++ b/.github/workflows/notify_docusaurus.yml
@@ -1,0 +1,18 @@
+name: Notify Docusaurus Repo
+
+on:
+  push:
+    branches:
+      - "autobuild-*" # Remove this after done with testing.
+      - develop
+      - main
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Docusaurus Update
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.DOCUSAURUS_PAT }}" \
+          --data '{"event_type": "sdk_update", "client_payload": { "repo": "'"${{ github.repository }}"'" }}' \
+          https://api.github.com/repos/Flyreel/flyreel-sdk-docs/dispatches


### PR DESCRIPTION
Purpose: 
This PR links this repo to the Docusaurus Docs Repo to talk to the Work Flow on there. It will move changes made in this repo and pass it to the Docs repo so it can create a new branch with those changes and create a PR for us to merge which will update the side automatically. 